### PR TITLE
Add request timeout and remove session timeout default

### DIFF
--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -180,7 +180,8 @@ class Test(unittest.TestCase):
                               consumer_group=self.consumer_group,
                               retry_on_fail=False,
                               verify_cert_bundle="cabundle.crt",
-                              timeout=60,
+                              request_timeout=70,
+                              session_timeout=60,
                               offset="earliest")
 
             self.assertEqual(channel._session.verify, "cabundle.crt")
@@ -194,6 +195,7 @@ class Test(unittest.TestCase):
                 json={
                     "consumerGroup": self.consumer_group,
                     "configs": {
+                        "request.timeout.ms": "70000",
                         "session.timeout.ms": "60000",
                         "enable.auto.commit": "false",
                         "auto.offset.reset": "earliest"
@@ -272,7 +274,6 @@ class Test(unittest.TestCase):
                  json={
                      "consumerGroup": self.consumer_group,
                      "configs": {
-                         "session.timeout.ms": "300000",
                          "auto.offset.reset": "latest",
                          "enable.auto.commit": "false"}}),
             call("post",
@@ -302,7 +303,6 @@ class Test(unittest.TestCase):
                  json={
                      "consumerGroup": self.consumer_group,
                      "configs": {
-                         "session.timeout.ms": "300000",
                          "auto.offset.reset": "latest",
                          "enable.auto.commit": "false"}}),
             call("post",


### PR DESCRIPTION
Previously, a 'timeout' value (the channel session timeout) could be
specified during channel creation, with a default value of 300 seconds.
At the streaming service, however, channel creation could fail if the
session timeout were greater than that of the request timeout.

This commit adds the ability to set the request and session timeouts
independently. The session timeout, if not set, now defaults to whatever
the streaming service would use (which should be less than that of the
default for the request timeout). The docstrings for the request and
session timeouts indicate that, if set, the request timeout should
exceed that of the session timeout in order to avoid problems with
channel creation.

This commit also removes the logic in the fake service which
inappropriately used the session timeout value from the channel
creation as a session expiration. The session timeout value should
only be used to validate the duration between keep alive heartbeats
sent periodically between the streaming service and its backend data
store.  A 'fake' implementation of the keep alive heartbeat could be
added in the future if needed.