### PR TITLE
Add producer send method

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -134,7 +134,8 @@ disable=print-statement,
         too-many-statements,
         missing-docstring,
         protected-access,
-        similarities
+        similarities,
+        useless-object-inheritance
 
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.pylintrc.samples
+++ b/.pylintrc.samples
@@ -132,7 +132,8 @@ disable=missing-docstring,
         dict-keys-not-iterating,
         dict-values-not-iterating,
         invalid-name,
-        protected-access
+        protected-access,
+        useless-object-inheritance
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc.samples
+++ b/.pylintrc.samples
@@ -133,7 +133,14 @@ disable=missing-docstring,
         dict-values-not-iterating,
         invalid-name,
         protected-access,
-        useless-object-inheritance
+        useless-object-inheritance,
+        wrong-import-position,
+        wildcard-import,
+        unused-wildcard-import,
+        import-error,
+        undefined-variable,
+        similarities
+
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/doc/sdk/basicconsumeexample.rst
+++ b/doc/sdk/basicconsumeexample.rst
@@ -14,7 +14,7 @@ Prerequisites
 Setup
 *****
 
-Modify the example to include the appropriate settings for the consumer
+Modify the example to include the appropriate settings for the streaming
 service channel:
 
     .. code-block:: python
@@ -46,7 +46,7 @@ a command window:
 
 Messages like the following should appear in the command window:
 
-    .. code-block:: shell
+    .. parsed-literal::
 
         INFO:__main__:Starting service
         INFO:__main__:Started service on http://mycaseserver:50080
@@ -152,7 +152,8 @@ The majority of the sample code is shown below:
                         topics=CHANNEL_TOPIC_SUBSCRIPTIONS)
 
 
-The first step is to create a channel to the streaming service. The channel
+The first step is to create a :class:`dxlstreamingclient.channel.Channel`
+instance, which establishes a channel to the streaming service. The channel
 includes the URL to the streaming service, ``CHANNEL_URL``, and credentials
 that the client uses to authenticate itself to the service, ``CHANNEL_USERNAME``
 and ``CHANNEL_PASSWORD``.
@@ -165,11 +166,12 @@ continue consuming records. Note that if the ``process_callback`` function were
 to instead return ``False``, the ``run`` method would stop polling the service
 for new records and would instead return.
 
-The final step is to call the ``run`` method. The ``run`` method establishes a
-consumer instance with the service, subscribes the consumer instance for events
-delivered to the ``topics`` included in the ``CHANNEL_TOPIC_SUBSCRIPTIONS``
-variable, and continuously polls the streaming service for available records.
-The payloads from any records which are received from the streaming service are
-passed in a call to the ``process_callback`` function. Note that if no records
-are received from a poll attempt, an empty list of payloads is passed into the
-``process_callback`` function.
+The final step is to call the :meth:`dxlstreamingclient.channel.Channel.run`
+method. The ``run`` method establishes a consumer instance with the service,
+subscribes the consumer instance for events delivered to the ``topics``
+included in the ``CHANNEL_TOPIC_SUBSCRIPTIONS`` variable, and continuously
+polls the streaming service for available records. The payloads from any
+records which are received from the streaming service are passed in a call to
+the ``process_callback`` function. Note that if no records are received from a
+poll attempt, an empty list of payloads is passed into the ``process_callback``
+function.

--- a/doc/sdk/basicproduceexample.rst
+++ b/doc/sdk/basicproduceexample.rst
@@ -1,0 +1,149 @@
+Basic Produce Example
+=====================
+
+This sample demonstrates how to produce records to the DXL streaming service.
+
+Prerequisites
+*************
+
+* A DXL streaming service is available for the sample to connect to.
+* Credentials for the service available for use with the sample.
+
+Setup
+*****
+
+Modify the example to include the appropriate settings for the streaming
+service channel:
+
+    .. code-block:: python
+
+        CHANNEL_URL = "http://127.0.0.1:50080"
+        CHANNEL_USERNAME = "me"
+        CHANNEL_PASSWORD = "secret"
+        CHANNEL_TOPIC = "my-topic"
+        # Path to a CA bundle file containing certificates of trusted CAs. The CA
+        # bundle is used to validate that the certificate of the server being connected
+        # to was signed by a valid authority. If set to an empty string, the server
+        # certificate is not validated.
+        VERIFY_CERTIFICATE_BUNDLE = ""
+
+
+For testing purposes, you can use the ``fake_streaming_service`` Python tool
+embedded in the OpenDXL Streaming Client SDK to start up a local
+streaming service. The initial settings in the example above include the URL
+and credentials used by the ``fake_streaming_service``.
+
+To launch the ``fake_streaming_service`` tool, run the following command in
+a command window:
+
+    .. code-block:: shell
+
+        python sample/fake_streaming_service.py
+
+Messages like the following should appear in the command window:
+
+    .. code-block:: shell
+
+        INFO:__main__:Starting service
+        INFO:__main__:Started service on http://mycaseserver:50080
+
+Running
+*******
+
+To run this sample execute the ``sample/basic/basic_produce_example.py`` script
+as follows:
+
+    .. parsed-literal::
+
+        python sample/basic/basic_produce_example.py
+
+If the records are successfully produced to the streaming service, the
+following line should appear in the output window:
+
+    .. parsed-literal::
+
+        Succeeded.
+
+To validate that the records were produced to the streaming service with
+the expected content, you can execute the
+``sample/basic/basic_consume_example.py`` script as follows:
+
+    .. parsed-literal::
+
+        python sample/basic/basic_consume_example.py
+
+One of the records received by the sample should appear similar to the
+following:
+
+    .. code-block:: shell
+
+        2018-05-30 17:35:36,754 __main__ - INFO - Received payloads:
+        [
+            ...
+            {
+                "message": "Hello from OpenDXL"
+            }
+            ...
+        ]
+
+Details
+*******
+
+The majority of the sample code is shown below:
+
+    .. code-block:: python
+
+        CHANNEL_TOPIC = "my-topic"
+
+        # Create the message payload to be included in a record
+        message_payload = {
+            "message": "Hello from OpenDXL"
+        }
+
+        # Create the full payload with records to produce to the channel
+        channel_payload = {
+            "records": [
+                {
+                    "routingData": {
+                        "topic": CHANNEL_TOPIC,
+                        "shardingKey": ""
+                    },
+                    "message": {
+                        "headers": {},
+                        # Convert the message payload from a dictionary to a
+                        # base64-encoded string.
+                        "payload": base64.b64encode(
+                            json.dumps(message_payload).encode()).decode()
+                    }
+                }
+            ]
+        }
+
+        # Create a new channel object
+        with Channel(CHANNEL_URL,
+                     auth=ChannelAuth(CHANNEL_URL,
+                                      CHANNEL_USERNAME,
+                                      CHANNEL_PASSWORD,
+                                      verify_cert_bundle=VERIFY_CERTIFICATE_BUNDLE),
+                     verify_cert_bundle=VERIFY_CERTIFICATE_BUNDLE) as channel:
+            # Produce the payload records to the channel
+            channel.produce(channel_payload)
+
+        print("Succeeded.")
+
+
+The first step is to create a payload dictionary which includes an array of
+records to be sent to the channel. The `message.payload` item in each record
+is flattened from a dictionary into a string and encoded using the ``base64``
+algorithm.
+
+The next step is to create a :class:`dxlstreamingclient.channel.Channel`
+instance, which establishes a channel to the streaming service. The channel
+parameters include the URL to the streaming service, ``CHANNEL_URL``, and
+credentials that the client uses to authenticate itself to the service,
+``CHANNEL_USERNAME`` and ``CHANNEL_PASSWORD``.
+
+The final step is to call the
+:meth:`dxlstreamingclient.channel.Channel.produce` method with the payload of
+records to be produced to the channel. Assuming the records can be produced
+successfully, the text "Succeeded." should appear in the console output.

--- a/doc/sdk/index.rst
+++ b/doc/sdk/index.rst
@@ -26,6 +26,7 @@ Basic
 	:maxdepth: 1
 
 	basicconsumeexample
+	basicproduceexample
 
 Python API
 ----------

--- a/dxlstreamingclient/channel.py
+++ b/dxlstreamingclient/channel.py
@@ -20,6 +20,7 @@ from ._compat import is_string
 
 _DEFAULT_CONSUMER_PATH_PREFIX = "/databus/consumer-service/v1"
 _DEFAULT_PRODUCER_PATH_PREFIX = "/databus/cloudproxy/v1"
+_PRODUCE_CONTENT_TYPE = "application/vnd.dxl.intel.records.v1+json"
 
 _RETRY_WAIT_EXPONENTIAL_MULTIPLIER = 1000
 _RETRY_WAIT_EXPONENTIAL_MAX = 10000
@@ -140,10 +141,17 @@ class Channel(object):
             for channel requests.
         :param str consumer_group: Consumer group to subscribe the channel
             consumer to.
+        :param str path_prefix: Path to append to streaming service requests.
         :param str consumer_path_prefix: Path to append to consumer-related
-            requests made to the streaming service.
+            requests made to the streaming service. Note that if the
+            `path_prefix` parameter is set to a non-empty value, the
+            `path_prefix` value will be appended to consumer-related requests
+            instead of the `consumer_path_prefix` value.
         :param str producer_path_prefix: Path to append to producer-related
-            requests made to the streaming service.
+            requests made to the streaming service. Note that if the
+            `path_prefix` parameter is set to a non-empty value, the
+            `path_prefix` value will be appended to producer-related requests
+            instead of the `producer_path_prefix` value.
         :param str offset: Offset for the next record to retrieve from the
             streaming service for the new :meth:`consume` call. Must be one
             of 'latest', 'earliest', or 'none'.
@@ -564,7 +572,7 @@ class Channel(object):
         url = furl(self._base).add(path=self._producer_path_prefix).add(
             path="produce").url
 
-        headers = {"Content-Type": "application/vnd.dxl.intel.records.v1+json"}
+        headers = {"Content-Type": _PRODUCE_CONTENT_TYPE}
 
         res = self._post_request(url, json=payload, headers=headers)
 

--- a/dxlstreamingclient/channel.py
+++ b/dxlstreamingclient/channel.py
@@ -140,7 +140,10 @@ class Channel(object):
             for channel requests.
         :param str consumer_group: Consumer group to subscribe the channel
             consumer to.
-        :param str path_prefix: Path to append to streaming service requests.
+        :param str consumer_path_prefix: Path to append to consumer-related
+            requests made to the streaming service.
+        :param str producer_path_prefix: Path to append to producer-related
+            requests made to the streaming service.
         :param str offset: Offset for the next record to retrieve from the
             streaming service for the new :meth:`consume` call. Must be one
             of 'latest', 'earliest', or 'none'.
@@ -550,11 +553,18 @@ class Channel(object):
                     self._stopped_condition.wait()
 
     def produce(self, payload):
-        url = furl(self._base).add(path=self._producer_path_prefix).add(
-            path="produce"
-        )
+        """
+        Produces records to the channel.
 
-        headers = {'Content-Type': 'application/vnd.dxl.intel.records.v1+json'}
+        :param payload: Payload containing the records to be posted to the
+            channel.
+        :raise PermanentError: if an unsuccessful response is received from
+            the streaming service.
+        """
+        url = furl(self._base).add(path=self._producer_path_prefix).add(
+            path="produce").url
+
+        headers = {"Content-Type": "application/vnd.dxl.intel.records.v1+json"}
 
         res = self._post_request(url, json=payload, headers=headers)
 

--- a/dxlstreamingclient/channel.py
+++ b/dxlstreamingclient/channel.py
@@ -554,7 +554,9 @@ class Channel(object):
             path="produce"
         )
 
-        res = self._post_request(url, json=payload)
+        headers = {'Content-Type': 'application/vnd.dxl.intel.records.v1+json'}
+
+        res = self._post_request(url, json=payload, headers=headers)
 
         if res.status_code not in [200, 201, 202, 204]:
             raise PermanentError(

--- a/sample/basic/basic_consume_example.py
+++ b/sample/basic/basic_consume_example.py
@@ -22,7 +22,9 @@ CHANNEL_URL = "http://127.0.0.1:50080"
 CHANNEL_USERNAME = "me"
 CHANNEL_PASSWORD = "secret"
 CHANNEL_CONSUMER_GROUP = "sample_consumer_group"
-CHANNEL_TOPIC_SUBSCRIPTIONS = ["case-mgmt-events", "my-topic"]
+CHANNEL_TOPIC_SUBSCRIPTIONS = ["case-mgmt-events",
+                               "my-topic",
+                               "topic-abc123"]
 # Path to a CA bundle file containing certificates of trusted CAs. The CA
 # bundle is used to validate that the certificate of the server being connected
 # to was signed by a valid authority. If set to an empty string, the server

--- a/sample/basic/basic_produce_example.py
+++ b/sample/basic/basic_produce_example.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import print_function
 import base64
 import json
 import os

--- a/sample/basic/basic_produce_example.py
+++ b/sample/basic/basic_produce_example.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import base64
 import json
 import os
 import sys
@@ -21,17 +22,32 @@ logger = logging.getLogger(__name__)
 CHANNEL_URL = "http://127.0.0.1:50080"
 CHANNEL_USERNAME = "me"
 CHANNEL_PASSWORD = "secret"
-CHANNEL_CONSUMER_GROUP = "sample_consumer_group"
-CHANNEL_TOPIC_SUBSCRIPTIONS = ["case-mgmt-events", "my-topic"]
+CHANNEL_TOPIC = "my-topic"
 # Path to a CA bundle file containing certificates of trusted CAs. The CA
 # bundle is used to validate that the certificate of the server being connected
 # to was signed by a valid authority. If set to an empty string, the server
 # certificate is not validated.
 VERIFY_CERTIFICATE_BUNDLE = ""
 
-# This constant controls the frequency (in seconds) at which the channel 'run'
-# call below polls the streaming service for new records.
-WAIT_BETWEEN_QUERIES = 5
+message_payload = {
+    "message": "Hello from OpenDXL"
+}
+
+channel_payload = {
+    "records": [
+        {
+            "routingData": {
+                "topic": CHANNEL_TOPIC,
+                "shardingKey": ""
+            },
+            "message": {
+                "headers": {},
+                "payload": base64.b64encode(
+                    json.dumps(message_payload).encode())
+            }
+        }
+    ]
+}
 
 # Create a new channel object
 with Channel(CHANNEL_URL,
@@ -39,21 +55,7 @@ with Channel(CHANNEL_URL,
                               CHANNEL_USERNAME,
                               CHANNEL_PASSWORD,
                               verify_cert_bundle=VERIFY_CERTIFICATE_BUNDLE),
-             consumer_group=CHANNEL_CONSUMER_GROUP,
              verify_cert_bundle=VERIFY_CERTIFICATE_BUNDLE) as channel:
+    channel.produce(channel_payload)
 
-    # Create a function which will be called back upon by the 'run' method (see
-    # below) when records are received from the channel.
-    def process_callback(payloads):
-        # Print the payloads which were received. 'payloads' is a list of
-        # dictionary objects extracted from the records received from the
-        # channel.
-        logger.info("Received payloads: \n%s",
-                    json.dumps(payloads, indent=4, sort_keys=True))
-        # Return 'True' in order for the 'run' call to continue attempting to
-        # consume records.
-        return True
-
-    # Consume records indefinitely
-    channel.run(process_callback, wait_between_queries=WAIT_BETWEEN_QUERIES,
-                topics=CHANNEL_TOPIC_SUBSCRIPTIONS)
+print("Succeeded.")

--- a/sample/basic/basic_produce_example.py
+++ b/sample/basic/basic_produce_example.py
@@ -29,10 +29,12 @@ CHANNEL_TOPIC = "my-topic"
 # certificate is not validated.
 VERIFY_CERTIFICATE_BUNDLE = ""
 
+# Create the message payload to be included in a record
 message_payload = {
     "message": "Hello from OpenDXL"
 }
 
+# Create the full payload with records to produce to the channel
 channel_payload = {
     "records": [
         {
@@ -42,6 +44,8 @@ channel_payload = {
             },
             "message": {
                 "headers": {},
+                # Convert the message payload from a dictionary to a
+                # base64-encoded string.
                 "payload": base64.b64encode(
                     json.dumps(message_payload).encode()).decode()
             }
@@ -56,6 +60,7 @@ with Channel(CHANNEL_URL,
                               CHANNEL_PASSWORD,
                               verify_cert_bundle=VERIFY_CERTIFICATE_BUNDLE),
              verify_cert_bundle=VERIFY_CERTIFICATE_BUNDLE) as channel:
+    # Produce the payload records to the channel
     channel.produce(channel_payload)
 
 print("Succeeded.")

--- a/sample/basic/basic_produce_example.py
+++ b/sample/basic/basic_produce_example.py
@@ -43,7 +43,7 @@ channel_payload = {
             "message": {
                 "headers": {},
                 "payload": base64.b64encode(
-                    json.dumps(message_payload).encode())
+                    json.dumps(message_payload).encode()).decode()
             }
         }
     ]

--- a/sample/fake_streaming_service.py
+++ b/sample/fake_streaming_service.py
@@ -31,7 +31,9 @@ USE_SSL = False
 REQUESTS_PER_TOKEN = 25
 RUN_CHECK_WAIT = 5
 MAX_SHUTDOWN_WAIT = 10
-PATH_PREFIX = "/databus/consumer-service/v1"
+
+CONSUMER_PATH_PREFIX = "/databus/consumer-service/v1"
+PRODUCER_PATH_PREFIX = "/databus/cloudproxy/v1"
 
 AUTH_USER = "me"
 AUTH_PASSWORD = "secret"
@@ -41,9 +43,12 @@ AUTH_USER_HEADER = "Basic {}".format(base64.b64encode(
 COOKIE_NAME = "AWSALB"
 CONSUMER_GROUP = "sample_consumer_group"
 
+PARTITION = 1
+INITIAL_OFFSET = 100
 
 def encode_payload(obj):
     return base64.b64encode(json.dumps(obj).encode()).decode()
+
 
 DEFAULT_RECORDS = [
     {
@@ -75,8 +80,8 @@ DEFAULT_RECORDS = [
                     }
             })
         },
-        "partition": 1,
-        "offset": 100
+        "partition": PARTITION,
+        "offset": INITIAL_OFFSET
     },
     {
         "routingData": {
@@ -108,16 +113,20 @@ DEFAULT_RECORDS = [
                     }
             })
         },
-        "partition": 1,
-        "offset": 101
+        "partition": PARTITION,
+        "offset": INITIAL_OFFSET + 1
     }
 ]
 
 LOG = logging.getLogger(__name__)
 
 
-def create_service_path(subpath):
-    return "^{}/{}$".format(PATH_PREFIX, subpath)
+def create_consumer_service_path(subpath):
+    return "^{}/{}$".format(CONSUMER_PATH_PREFIX, subpath)
+
+
+def create_producer_service_path(subpath):
+    return "^{}/{}$".format(PRODUCER_PATH_PREFIX, subpath)
 
 
 def consumer_service_handler(consumer_service):
@@ -126,16 +135,17 @@ def consumer_service_handler(consumer_service):
             self._consumer_service = consumer_service
             self._routes = {
                 "^/identity/v1/login$": {"GET": _login},
-                create_service_path("consumers/[^/]+/records"):
+                create_consumer_service_path("consumers/[^/]+/records"):
                     {"GET": _get_records},
-                create_service_path("consumers"): {"POST": _create_consumer},
-                create_service_path("consumers/[^/]+/subscription"):
+                create_consumer_service_path("consumers"): {"POST": _create_consumer},
+                create_consumer_service_path("consumers/[^/]+/subscription"):
                     {"POST": _create_subscription},
-                create_service_path("consumers/[^/]+/offsets"):
+                create_consumer_service_path("consumers/[^/]+/offsets"):
                     {"POST": _commit_offsets},
                 "^/reset-records$": {"POST": _reset_records},
-                "^/record": {"POST": _create_record},
-                create_service_path("consumers/[^/]+"):
+                create_producer_service_path("produce"):
+                    {"POST": _produce_record},
+                create_consumer_service_path("consumers/[^/]+"):
                     {"DELETE": _delete_consumer}
             }
             SimpleHTTPRequestHandler.__init__(self, request, client_address,
@@ -198,6 +208,7 @@ class ConsumerService(object):
     def __init__(self, port=DEFAULT_PORT, config_file=None):
         self._active_consumers = {}
         self._active_records = list(DEFAULT_RECORDS)
+        self._offset = INITIAL_OFFSET + len(self._active_records)
         self._lock = threading.Lock()
         self._server = None
         self._server_thread = None
@@ -473,22 +484,23 @@ def _commit_offsets(body, consumer_service, **kwargs): # pylint: disable=unused-
 
 
 @_json_body
-def _create_record(body, consumer_service, **kwargs): # pylint: disable=unused-argument
+def _produce_record(body, consumer_service, **kwargs): # pylint: disable=unused-argument
     status_code = 200
     response = ""
     with consumer_service._lock:
-        if "message" in body and "payload" in body["message"]:
-            payload = body["message"]["payload"]
-            if isinstance(payload, dict):
-                body["message"]["payload"] = encode_payload(payload)
-            consumer_service._active_records.append(body)
-        else:
-            response = "No payload in record"
+        for record in body["records"]:
+            record["partition"] = PARTITION
+            record["offset"] = consumer_service._offset
+            consumer_service._offset += 1
+            consumer_service._active_records.append(record)
     return status_code, response
+
 
 def _reset_records(consumer_service, **kwargs): # pylint: disable=unused-argument
     with consumer_service._lock:
         consumer_service._active_records = list(DEFAULT_RECORDS)
+        consumer_service._offset = \
+            INITIAL_OFFSET + len(consumer_service._active_records)
     return 200, ""
 
 

--- a/sample/fake_streaming_service.py
+++ b/sample/fake_streaming_service.py
@@ -34,6 +34,7 @@ MAX_SHUTDOWN_WAIT = 10
 
 CONSUMER_PATH_PREFIX = "/databus/consumer-service/v1"
 PRODUCER_PATH_PREFIX = "/databus/cloudproxy/v1"
+PRODUCE_CONTENT_TYPE = "application/vnd.dxl.intel.records.v1+json"
 
 AUTH_USER = "me"
 AUTH_PASSWORD = "secret"
@@ -525,7 +526,7 @@ def _commit_offsets(body, consumer_service, **kwargs): # pylint: disable=unused-
 def _produce_record(body, consumer_service, content_type, **kwargs): # pylint: disable=unused-argument
     status_code = 200
     response = ""
-    if content_type == "application/vnd.dxl.intel.records.v1+json":
+    if content_type == PRODUCE_CONTENT_TYPE:
         with consumer_service._lock:
             for record in body["records"]:
                 record["partition"] = PARTITION

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class LintCommand(Command):
             glob.glob("*.py"))
         self.announce("Running pylint for samples", level=distutils.log.INFO)
         subprocess.check_call(["pylint"] + glob.glob("sample/*.py") +
-                              glob.glob("examples/**/*.py") +
+                              glob.glob("sample/**/*.py") +
                               ["--rcfile", ".pylintrc.samples"])
 
 class CiCommand(Command):

--- a/tests/test_fake_service.py
+++ b/tests/test_fake_service.py
@@ -30,12 +30,17 @@ class Test(unittest.TestCase):
                          consumer_group=fake_streaming_service.CONSUMER_GROUP) \
                     as channel:
                 channel.create()
-                channel.subscribe("case-mgmt-events")
+                topic = "case-mgmt-events"
+                channel.subscribe(topic)
 
-                expected_records = \
-                    [json.loads(base64.b64decode(
-                        record['message']['payload']).decode())
-                     for record in fake_streaming_service.DEFAULT_RECORDS]
+                expected_records = []
+                for record in fake_streaming_service.DEFAULT_RECORDS:
+                    if record['routingData']['topic'] == topic:
+                        expected_records.append(
+                            json.loads(base64.b64decode(
+                                record['message']['payload']).decode())
+                        )
+
                 records_consumed = channel.consume()
                 self.assertEqual(expected_records, records_consumed)
 


### PR DESCRIPTION
This PR adds a `produce()` method to the `Channel` class. The method can
be used to send a payload of records to a producer service.

Separate path prefix parameters were also added to the `Channel` class
constructor for distinguishing consumer (`consumer_path_prefix`) vs.
producer (`producer_path_prefix`) requests. If the legacy `path_prefix`
parameter is set to an explicit value, that value will, for backward
compatibility, override both the `consumer_path_prefix` and
`producer_path_prefix` parameters.

A new example, "Basic Produce Example", was added to demonstrate
the use of the `produce()` method, along with some modifications to the
`fake_streaming_service`.