### PR TITLE
Retry an initial channel produce failure

### DIFF
--- a/sample/fake_streaming_service.py
+++ b/sample/fake_streaming_service.py
@@ -522,6 +522,7 @@ def _commit_offsets(body, consumer_service, **kwargs): # pylint: disable=unused-
     return 204, ""
 
 
+@_token_auth
 @_json_body
 def _produce_record(body, consumer_service, content_type, **kwargs): # pylint: disable=unused-argument
     status_code = 200


### PR DESCRIPTION
Previously, if a call to the channel `produce` method were to fail due
to the channel token having expired, no attempt was made to
automatically re-authenticate, attempt to obtain a new token, and repeat
the call to the `produce` method.

With the changes in this commit, an initial failure in a call to the
`produce` method will be retried, with an attempt made to re-authenticate
and obtain a new token before the second attempt to perform the
`produce` call. An error is raised if consecutive calls fail.